### PR TITLE
Add an option for setting JPEG quality/PNG compression level

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Options being
   width: Int,
   height: Int,
   ?crop: Bool, // Defaults to true
-  ?focus: {x: Float, y: Float} // Defaults to {x: .5, y: .5}
+  ?focus: {x: Float, y: Float}, // Defaults to {x: .5, y: .5}
+  ?quality: Int // Engine- and format-dependent
 }
 ```
 Resize and crop a file from the center:
@@ -62,3 +63,13 @@ Image
       trace('Something went wrong: '+ error.message);
   });
 ```
+
+#### Options.quality
+For GD, the quality option is only used when the output format is JPEG. If not set, the default value is 96.
+
+For ImageMagick and GraphicsMagick, this is passed as the `-quality` option into the command, only having effect for JPEG and PNG.
+If not set, the value is determined by the program (usually, the quality setting of the original image is used).
+See [ImageMagick documentation](https://imagemagick.org/script/command-line-options.php#quality)
+
+For VIPS, the option is ignored.
+

--- a/src/image/Image.hx
+++ b/src/image/Image.hx
@@ -32,7 +32,8 @@ typedef Options = {
 	width: Int,
 	height: Int,
 	?crop: Bool,
-	?focus: {x: Float, y: Float}
+	?focus: {x: Float, y: Float},
+	?quality: Int,
 }
 
 typedef ImageInfo = {
@@ -110,7 +111,8 @@ class Image {
 						case 'gif':
 								Gd.imagegif(dst, output);
 						case 'jpg' | 'jpeg':
-								Gd.imagejpeg(dst, output, 96);
+								final quality = if (options.quality != null) options.quality else 96;
+								Gd.imagejpeg(dst, output, quality);
 						case 'png':
 								Gd.imagepng(dst, output, 9);
 						case 'bmp':
@@ -143,14 +145,22 @@ class Image {
 					[input,
 						'-resize', '${width}x${height}',
 						'-crop', '${options.width}x${options.height}+${xPos}+$yPos',
-						'-strip', '+repage',
-					output];
+						'-strip', '+repage'
+					].concat(
+						if (options.quality != null)
+							['-quality', '${options.quality}']
+						else []
+					).concat([output]);
 				case Engine.GraphicsMagick:
 					['convert', input,
 						'-resize', '${width}x${height}',
 						'-crop', '${options.width}x${options.height}+${xPos}+$yPos',
-						'-strip', '+repage',
-					output];
+						'-strip', '+repage'
+					].concat(
+						if (options.quality != null)
+							['-quality', '${options.quality}']
+						else []
+					).concat([output]);
 				default: null;
 			}
 			var process = new Process(cmd, args);


### PR DESCRIPTION
I've made this patch for a personal project and figured someone might appreciate it too. I am not very happy about the implementation though, it feels hacky.

There is also a way to set the quality in VIPS (see https://manpages.debian.org/testing/libvips-tools/vipsthumbnail.1.en.html) which would be good to implement before merging.